### PR TITLE
added password tunnelling through X-Authenticate

### DIFF
--- a/application-passwords.php
+++ b/application-passwords.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Plugin Name: Application Passwords
- * Plugin URI: http://github.com/georgestephanis/application-passwords/
- * Description: A prototype framework to add application passwords to core.
+ * Plugin Name: Omnistream Application Passwords
+ * Plugin URI: https://github.com/jtosey/application-passwords
+ * Description: A prototype framework to add application passwords to core
  * Author: George Stephanis
  * Version: 0.1-dev
  * Author URI: http://stephanis.info

--- a/readme.md
+++ b/readme.md
@@ -48,10 +48,14 @@ echo -n "admin:mypassword123" | base64
 
 2. Once your username and password are base64 encoded, you are now able to make a simple REST API call using the terminal window to update a post.  Because you are performing a POST request, you will need to authorize the request using your newly created base64 encoded access token. If authorized correctly, you will see the post title update to "New Title."
 ```shell
-curl --header "Authorization: Basic ACCESS_TOKEN" -X POST -d "title=New Title" http://LOCALHOST/wp-json/wp/v2/posts/POST_ID}
+curl --header "Authorization: Basic ACCESS_TOKEN" -X POST -d "title=New Title" http://LOCALHOST/wp-json/wp/v2/posts/POST_ID
 ```
    When running this command, be sure to replace *ACCESS_TOKEN* with your newly generated access token, *LOCALHOST* with the location of your local WordPress installation, and *POST_ID* with the ID of the post that you want to edit.
 
+   If your hosting provider filters out the Authorization header, you can alternatively use this syntax.
+```shell
+curl --header "X-Authorization: Basic ACCESS_TOKEN" -X POST -d "title=New Title" http://LOCALHOST/wp-json/wp/v2/posts/POST_ID
+```
 ## XML-RPC
 
 This test uses the technologies listed below, but you can use any XML-RPC request.


### PR DESCRIPTION
Hi,

I found I could use this package on Bluehost, but could not use it on GoDaddy because they filter the Authentication header.  I've modified it so that it accepts credentials using either Authentication: or X-Authentication: headers.  We'll be using the patched version and populating both authentication headers, which allows us to use it with any hosting site.

Thanks for the great base package - I'm not sure you'll want to include this patch, but I thought I would make it available.

Cheers
Joseph