### PR TITLE
Fix Passwords Table Order

### DIFF
--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -359,7 +359,7 @@ class Application_Passwords {
 			<?php
 				require( dirname( __FILE__ ) . '/class.application-passwords-list-table.php' );
 				$application_passwords_list_table = new Application_Passwords_List_Table();
-				$application_passwords_list_table->items = self::get_user_application_passwords( $user->ID );
+				$application_passwords_list_table->items = array_reverse( self::get_user_application_passwords( $user->ID ) );
 				$application_passwords_list_table->prepare_items();
 				$application_passwords_list_table->display();
 			?>


### PR DESCRIPTION
* FIXED: Passwords are now ordered from newest to oldest so that when a new password is added it will be prepended to the top of the table and keep the order of the table

From issue https://github.com/georgestephanis/application-passwords/issues/28

@georgestephanis let me know if this is what you were thinking.