### PR TITLE
Don't use is_a

### DIFF
--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -251,7 +251,7 @@ class Application_Passwords {
 
 		$user = self::authenticate( $input_user, $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'] );
 
-		if ( is_a( $user, 'WP_User' ) ) {
+		if ( $user instanceof 'WP_User' ) {
 			return $user->ID;
 		}
 


### PR DESCRIPTION
is_a was deprecated in PHP 5.0 before being restored in 5.3, thus PHP 5.2 users will get a deprecation notice thrown

Ref: http://php.net/manual/en/function.is-a.php