### PR TITLE
Prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/application-passwords.php
+++ b/application-passwords.php
@@ -8,6 +8,8 @@
  * Author URI: http://stephanis.info
  */
 
+define( 'APPLICATION_PASSWORDS_VERSION', '0.1-dev' );
+
 /**
  * Include the application passwords system.
  */

--- a/auth-app.js
+++ b/auth-app.js
@@ -1,4 +1,4 @@
-
+/* global authApp */
 (function($,authApp){
 	var $appNameField = $('#app_name'),
 		$approveBtn   = $('#approve'),

--- a/auth-app.js
+++ b/auth-app.js
@@ -36,7 +36,6 @@
 					'user_login=' + encodeURIComponent( authApp.user_login ) +
 					'&password=' + encodeURIComponent( response.password );
 
-				// @todo: Make a better way to do this so it feels like less of a semi-open redirect.
 				window.location = url;
 			} else {
 

--- a/auth-app.js
+++ b/auth-app.js
@@ -1,11 +1,11 @@
 /* global authApp */
-(function($,authApp){
-	var $appNameField = $('#app_name'),
-		$approveBtn   = $('#approve'),
-		$rejectBtn    = $('#reject'),
-		$form         = $appNameField.closest('form');
+(function( $, authApp ) {
+	var $appNameField = $( '#app_name' ),
+		$approveBtn   = $( '#approve' ),
+		$rejectBtn    = $( '#reject' ),
+		$form         = $appNameField.closest( 'form' );
 
-	$approveBtn.click( function(e){
+	$approveBtn.click( function( e ) {
 		e.preventDefault();
 		var name = $appNameField.val();
 
@@ -48,21 +48,21 @@
 
 				var $display = $('.js-password-display');
 				// We're using .text() to write the variables to avoid any chance of XSS
-				$display.find('strong').text( name );
-				$display.find('kbd').text( response.password );
+				$display.find( 'strong' ).text( name );
+				$display.find( 'kbd' ).text( response.password );
 			}
 		} );
 	});
 
-	$rejectBtn.click( function(e){
+	$rejectBtn.click( function( e ) {
 		e.preventDefault();
 
 		// @todo: Make a better way to do this so it feels like less of a semi-open redirect.
 		window.location = authApp.reject;
 	});
 
-	$form.on( 'submit', function(e){
+	$form.on( 'submit', function( e ) {
 		e.preventDefault();
 	});
 
-})(jQuery,authApp);
+})( jQuery, authApp );

--- a/auth-app.js
+++ b/auth-app.js
@@ -6,8 +6,9 @@
 		$form         = $appNameField.closest( 'form' );
 
 	$approveBtn.click( function( e ) {
-		e.preventDefault();
 		var name = $appNameField.val();
+
+		e.preventDefault();
 
 		if ( 0 === name.length ) {
 			$appNameField.focus();
@@ -18,35 +19,36 @@
 		$approveBtn.prop( 'disabled', true );
 
 		$.ajax( {
-			url        : authApp.root + authApp.namespace + '/application-passwords/' + authApp.user_id + '/add',
-			method     : 'POST',
-			beforeSend : function ( xhr ) {
+			url: authApp.root + authApp.namespace + '/application-passwords/' + authApp.user_id + '/add',
+			method: 'POST',
+			beforeSend: function( xhr ) {
 				xhr.setRequestHeader( 'X-WP-Nonce', authApp.nonce );
 			},
-			data       : {
-				name : name
+			data: {
+				name: name
 			}
-		} ).done( function ( response ) {
+		} ).done( function( response ) {
 			var raw = authApp.success,
-				url;
+				url, $display;
 
 			if ( raw ) {
-				url = raw + ( -1 === raw.indexOf('?') ? '?' : '&' ) +
-					'user_login=' + encodeURIComponent(authApp.user_login) +
-					'&password=' + encodeURIComponent(response.password);
+				url = raw + ( -1 === raw.indexOf( '?' ) ? '?' : '&' ) +
+					'user_login=' + encodeURIComponent( authApp.user_login ) +
+					'&password=' + encodeURIComponent( response.password );
 
 				// @todo: Make a better way to do this so it feels like less of a semi-open redirect.
 				window.location = url;
 			} else {
+
 				// Should we maybe just reuse the js template modal from the profile page?
 				$form.replaceWith( '<p class="js-password-display">' +
-					// This is an awkward way of doing sprintf in js so we can reuse a translation.
 					authApp.strings.new_pass
 						.replace( '%1$s', '<strong></strong>' )
 						.replace( '%2$s', '<kbd></kbd>' ) +
 					'</p>' );
 
-				var $display = $('.js-password-display');
+				$display = $( '.js-password-display' );
+
 				// We're using .text() to write the variables to avoid any chance of XSS
 				$display.find( 'strong' ).text( name );
 				$display.find( 'kbd' ).text( response.password );

--- a/auth-app.js
+++ b/auth-app.js
@@ -1,0 +1,68 @@
+
+(function($,authApp){
+	var $appNameField = $('#app_name'),
+		$approveBtn   = $('#approve'),
+		$rejectBtn    = $('#reject'),
+		$form         = $appNameField.closest('form');
+
+	$approveBtn.click( function(e){
+		e.preventDefault();
+		var name = $appNameField.val();
+
+		if ( 0 === name.length ) {
+			$appNameField.focus();
+			return;
+		}
+
+		$appNameField.prop( 'disabled', true );
+		$approveBtn.prop( 'disabled', true );
+
+		$.ajax( {
+			url        : authApp.root + authApp.namespace + '/application-passwords/' + authApp.user_id + '/add',
+			method     : 'POST',
+			beforeSend : function ( xhr ) {
+				xhr.setRequestHeader( 'X-WP-Nonce', authApp.nonce );
+			},
+			data       : {
+				name : name
+			}
+		} ).done( function ( response ) {
+			var raw = authApp.success,
+				url;
+
+			if ( raw ) {
+				url = raw + ( -1 === raw.indexOf('?') ? '?' : '&' ) +
+					'user_login=' + encodeURIComponent(authApp.user_login) +
+					'&password=' + encodeURIComponent(response.password);
+
+				// @todo: Make a better way to do this so it feels like less of a semi-open redirect.
+				window.location = url;
+			} else {
+				// Should we maybe just reuse the js template modal from the profile page?
+				$form.replaceWith( '<p class="js-password-display">' +
+					// This is an awkward way of doing sprintf in js so we can reuse a translation.
+					authApp.strings.new_pass
+						.replace( '%1$s', '<strong></strong>' )
+						.replace( '%2$s', '<kbd></kbd>' ) +
+					'</p>' );
+
+				var $display = $('.js-password-display');
+				// We're using .text() to write the variables to avoid any chance of XSS
+				$display.find('strong').text( name );
+				$display.find('kbd').text( response.password );
+			}
+		} );
+	});
+
+	$rejectBtn.click( function(e){
+		e.preventDefault();
+
+		// @todo: Make a better way to do this so it feels like less of a semi-open redirect.
+		window.location = authApp.reject;
+	});
+
+	$form.on( 'submit', function(e){
+		e.preventDefault();
+	});
+
+})(jQuery,authApp);

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -395,12 +395,12 @@ class Application_Passwords {
 	 * Page for authorizing applications.
 	 */
 	public static function auth_app_page() {
-		$app_name    = ! empty( $_GET['app_name'] ) ? $_GET['app_name'] : '';
-		$success_url = ! empty( $_GET['success_url'] ) ? $_GET['success_url'] : null;
-		$reject_url  = ! empty( $_GET['reject_url'] ) ? $_GET['reject_url'] : $success_url;
+		$app_name    = ! empty( $_GET['app_name'] ) ? $_GET['app_name'] : ''; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		$success_url = ! empty( $_GET['success_url'] ) ? $_GET['success_url'] : null; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		$reject_url  = ! empty( $_GET['reject_url'] ) ? $_GET['reject_url'] : $success_url; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 		$user        = wp_get_current_user();
 
-		wp_enqueue_script( 'auth-app', plugin_dir_url( __FILE__ ) . 'auth-app.js', array() );
+		wp_enqueue_script( 'auth-app', plugin_dir_url( __FILE__ ) . 'auth-app.js', array(), APPLICATION_PASSWORDS_VERSION, true );
 		wp_localize_script(
 			'auth-app',
 			'authApp',
@@ -413,7 +413,7 @@ class Application_Passwords {
 				'success'    => $success_url,
 				'reject'     => $reject_url ? $reject_url : admin_url(),
 				'strings'    => array(
-					// translators: application, password
+					// translators: application, password.
 					'new_pass' => esc_html_x( 'Your new password for %1$s is: %2$s', 'application, password' ),
 				),
 			)
@@ -425,7 +425,12 @@ class Application_Passwords {
 			<div class="card js-auth-app-card">
 				<h2 class="title"><?php esc_html_e( 'An application would like to connect to your account.' ); ?></h2>
 				<?php if ( $app_name ) : ?>
-					<p><?php printf( esc_html__( 'Would you like to give the application identifying itself as %1$s access to your account?  You should only do this if you trust the app in question.' ), '<strong>' . esc_html( $app_name ) . '</strong>' ); ?></p>
+					<p>
+                    <?php
+                    // translators: application name
+                    printf( esc_html__( 'Would you like to give the application identifying itself as %1$s access to your account?  You should only do this if you trust the app in question.' ), '<strong>' . esc_html( $app_name ) . '</strong>' );
+                    ?>
+                    </p>
 				<?php else : ?>
 					<p><?php esc_html_e( 'Would you like to give this application access to your account?  You should only do this if you trust the app in question.' ); ?></p>
 				<?php endif; ?>
@@ -440,21 +445,48 @@ class Application_Passwords {
 
 					<p><?php submit_button( __( 'Yes, I approve of this connection.' ), 'primary', 'approve', false ); ?>
 						<br /><em>
-						<?php if ( $success_url ) : ?>
-							<?php printf( esc_html_x( 'You will be sent to %1$s', '%1$s is a url' ), '<strong><tt>' . esc_html( add_query_arg( array( 'username' => $user->user_login, 'password' => '[------]' ), $success_url ) ) . '</tt></strong>' ); ?>
-						<?php else : ?>
-							<?php esc_html_e( 'You will be given a password to manually enter into the application in question.' ); ?>
-						<?php endif; ?>
+						<?php
+						if ( $success_url ) {
+                            // translators: url
+							printf(
+                                esc_html_x( 'You will be sent to %1$s', '%1$s is a url' ),
+                                '<strong><kbd>' . esc_html(
+                                    add_query_arg(
+							            array(
+                                            'username' => $user->user_login,
+                                            'password' => '[------]'
+                                        ),
+                                        $success_url
+                                    )
+                                ) . '</kbd></strong>'
+                            );
+						} else {
+							esc_html_e( 'You will be given a password to manually enter into the application in question.' );
+						}
+                        ?>
 						</em>
 					</p>
 
 					<p><?php submit_button( __( 'No, I do not approve of this connection.' ), 'secondary', 'reject', false ); ?>
 						<br /><em>
-						<?php if ( $reject_url ) : ?>
-							<?php printf( esc_html_x( 'You will be sent to %1$s', '%1$s is a url' ), '<strong><tt>' . esc_html( add_query_arg( array( 'success' => 'false' ), $reject_url ) ) . '</tt></strong>' ); ?>
-						<?php else : ?>
-							<?php esc_html_e( 'You will be returned to the WordPress Dashboard, and we will never speak of this again.' ); ?>
-						<?php endif; ?>
+						<?php
+                        if ( $reject_url ) {
+                            // translators: url
+                            printf(
+                                esc_html_x( 'You will be sent to %1$s', '%1$s is a url' ),
+                                '<strong><kbd>' . esc_html(
+                                    add_query_arg(
+                                        array(
+                                            'success' => 'false'
+                                        ),
+                                        $reject_url
+                                    )
+                                ) . '</kbd></strong>'
+                            );
+						} else {
+							esc_html_e( 'You will be returned to the WordPress Dashboard, and we will never speak of this again.' );
+                        }
+                        ?>
 						</em>
 					</p>
 
@@ -512,8 +544,8 @@ class Application_Passwords {
 	 * @param WP_User $user WP_User object of the logged-in user.
 	 */
 	public static function show_user_profile( $user ) {
-		wp_enqueue_style( 'application-passwords-css', plugin_dir_url( __FILE__ ) . 'application-passwords.css', array() );
-		wp_enqueue_script( 'application-passwords-js', plugin_dir_url( __FILE__ ) . 'application-passwords.js', array() );
+		wp_enqueue_style( 'application-passwords-css', plugin_dir_url( __FILE__ ) . 'application-passwords.css', array(), APPLICATION_PASSWORDS_VERSION );
+		wp_enqueue_script( 'application-passwords-js', plugin_dir_url( __FILE__ ) . 'application-passwords.js', array(), APPLICATION_PASSWORDS_VERSION, true );
 		wp_localize_script( 'application-passwords-js', 'appPass', array(
 			'root'       => esc_url_raw( rest_url() ),
 			'namespace'  => '2fa/v1',
@@ -551,7 +583,7 @@ class Application_Passwords {
 						<div class="new-application-password-content">
 							<?php
 							printf(
-								// translators: application, password
+								// translators: application, password.
 								esc_html_x( 'Your new password for %1$s is: %2$s', 'application, password' ),
 								'<strong>{{ data.name }}</strong>',
 								'<kbd>{{ data.password }}</kbd>'

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -29,12 +29,12 @@ class Application_Passwords {
 	 * @access public
 	 * @static
 	 */
-	 public static function add_hooks() {
- 		add_filter( 'authenticate',           array( __CLASS__, 'authenticate' ), 10, 3 );
- 		add_action( 'show_user_profile',      array( __CLASS__, 'show_user_profile' ) );
- 		add_action( 'rest_api_init',          array( __CLASS__, 'rest_api_init' ) );
- 		add_filter( 'determine_current_user', array( __CLASS__, 'rest_api_auth_handler' ), 20 );
- 		add_filter( 'wp_rest_server_class',   array( __CLASS__, 'wp_rest_server_class' ) );
+	public static function add_hooks() {
+		add_filter( 'authenticate',           array( __CLASS__, 'authenticate' ), 10, 3 );
+		add_action( 'show_user_profile',      array( __CLASS__, 'show_user_profile' ) );
+		add_action( 'rest_api_init',          array( __CLASS__, 'rest_api_init' ) );
+		add_filter( 'determine_current_user', array( __CLASS__, 'rest_api_auth_handler' ), 20 );
+		add_filter( 'wp_rest_server_class',   array( __CLASS__, 'wp_rest_server_class' ) );
 		add_action( 'admin_menu',             array( __CLASS__, 'admin_menu' ) );
 	}
 
@@ -334,28 +334,30 @@ class Application_Passwords {
 				<p><?php printf( esc_html__( 'Would you like to give the application identifying itself as %1$s access to your account?  You should only do this if you trust the app in question.' ), '<strong>' . esc_html( $title ) . '</strong>' ); ?></p>
 				<form action="#">
 					<?php
-						echo '<label for="app_title">' . esc_html__( 'Application Title:' ) . '</label> ';
-						printf( '<input type="text" id="app_title" name="app_title" value="%1$s" />', esc_attr( $title ) );
+					echo '<label for="app_title">' . esc_html__( 'Application Title:' ) . '</label> ';
+					printf( '<input type="text" id="app_title" name="app_title" value="%1$s" />', esc_attr( $title ) );
 
-						echo '<p>';
-						submit_button( __( 'Yes, I approve of this connection.' ), 'primary', 'approve', false );
-						if ( $success_url ) {
-							printf( '<input type="hidden" name="success_url" value="%1$s" />', esc_url( $success_url ) );
-							printf( __( '<br /><em>You will be sent to <strong><tt>%1$s</tt></strong></em>' ), esc_html( $success_url ) );
-						} else {
-							_e( '<br /><em>You will be given a password to manually enter into the application in question.</em>' );
-						}
-						echo '</p>';
+					echo '<p>';
+					submit_button( __( 'Yes, I approve of this connection.' ), 'primary', 'approve', false );
+					echo '<br /><em>';
+					if ( $success_url ) {
+						printf( '<input type="hidden" name="success_url" value="%1$s" />', esc_url( $success_url ) );
+						printf( esc_html__( 'You will be sent to %1$s' ), '<strong><tt>' . esc_html( $success_url ) . '</tt></strong>' );
+					} else {
+						esc_html_e( 'You will be given a password to manually enter into the application in question.' );
+					}
+					echo '</em></p>';
 
-						echo '<p>';
-						submit_button( __( 'No, I do not approve of this connection.' ), 'secondary', 'reject', false );
-						if ( $success_url ) {
-							printf( '<input type="hidden" name="reject_url" value="%1$s" />', esc_url( $reject_url ) );
-							printf( __( '<br /><em>You will be sent to <strong><tt>%1$s</tt></strong></em>' ), esc_html( $reject_url ) );
-						} else {
-							_e( '<br /><em>You will be returned to the WordPress Dashboard, and we will <strong>never speak of this again</strong>.</em>' );
-						}
-						echo '</p>';
+					echo '<p>';
+					submit_button( __( 'No, I do not approve of this connection.' ), 'secondary', 'reject', false );
+					echo '<br /><em>';
+					if ( $success_url ) {
+						printf( '<input type="hidden" name="reject_url" value="%1$s" />', esc_url( $reject_url ) );
+						printf( esc_html__( 'You will be sent to %1$s' ), '<strong><tt>' . esc_html( $reject_url ) . '</tt></strong>' );
+					} else {
+						esc_html_e( 'You will be returned to the WordPress Dashboard, and we will never speak of this again.' );
+					}
+					echo '</em></p>';
 					?>
 				</form>
 			</div>

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -419,7 +419,11 @@ class Application_Passwords {
 
 			<div class="card js-auth-app-card">
 				<h2 class="title"><?php esc_html_e( 'An application would like to connect to your account.' ); ?></h2>
-				<p><?php printf( esc_html__( 'Would you like to give the application identifying itself as %1$s access to your account?  You should only do this if you trust the app in question.' ), '<strong>' . esc_html( $app_name ) . '</strong>' ); ?></p>
+				<?php if ( $app_name ) : ?>
+					<p><?php printf( esc_html__( 'Would you like to give the application identifying itself as %1$s access to your account?  You should only do this if you trust the app in question.' ), '<strong>' . esc_html( $app_name ) . '</strong>' ); ?></p>
+				<?php else : ?>
+					<p><?php esc_html_e( 'Would you like to give this application access to your account?  You should only do this if you trust the app in question.' ); ?></p>
+				<?php endif; ?>
 				<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
 					<?php wp_nonce_field( 'authorize_application_password' ); ?>
 					<input type="hidden" name="action" value="authorize_application_password" />

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -36,8 +36,7 @@ class Application_Passwords {
 		add_filter( 'determine_current_user', array( __CLASS__, 'rest_api_auth_handler' ), 20 );
 		add_filter( 'wp_rest_server_class',   array( __CLASS__, 'wp_rest_server_class' ) );
 		add_action( 'admin_menu',             array( __CLASS__, 'admin_menu' ) );
-		add_action( 'admin_post_authorize_application_password',
-		                                      array( __CLASS__, 'authorize_application_password' ) );
+		add_action( 'admin_post_authorize_application_password', array( __CLASS__, 'authorize_application_password' ) );
 	}
 
 	/**
@@ -340,7 +339,7 @@ class Application_Passwords {
 			'reject'     => $reject_url ? $reject_url : admin_url(),
 			'strings'    => array(
 				'new_pass' => esc_html_x( 'Your new password for %1$s is: %2$s', 'application, password' ),
-			)
+			),
 		) );
 		?>
 		<div class="wrap">
@@ -365,7 +364,7 @@ class Application_Passwords {
 								'username' => $user->user_login,
 								'password' => '[------]',
 							), $success_url ) ) . '</tt></strong>' ); ?>
-						<?php else: ?>
+						<?php else : ?>
 							<?php esc_html_e( 'You will be given a password to manually enter into the application in question.' ); ?>
 						<?php endif; ?>
 						</em>
@@ -388,7 +387,7 @@ class Application_Passwords {
 	}
 
 	/**
-	 *
+	 * Handle non-JS submissions via traditional posting.
 	 */
 	public static function authorize_application_password() {
 		check_admin_referer( 'authorize_application_password' );
@@ -406,8 +405,7 @@ class Application_Passwords {
 		} elseif ( isset( $_POST['approve'] ) ) {
 			list( $new_password, $new_item ) = self::create_new_application_password( get_current_user_id(), $app_name );
 			if ( empty( $success_url ) ) {
-				wp_die( '<h1>' . esc_html__( 'Your New Application Password:' ) . '</h1>'
-						. '<h3><kbd>' . self::chunk_password( $new_password ) . '</kbd></h3>' );
+				wp_die( '<h1>' . esc_html__( 'Your New Application Password:' ) . '</h1><h3><kbd>' . esc_html( self::chunk_password( $new_password ) ) . '</kbd></h3>' );
 			}
 			$redirect = add_query_arg( array(
 				'username' => wp_get_current_user()->user_login,

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -30,13 +30,13 @@ class Application_Passwords {
 	 * @static
 	 */
 	public static function add_hooks() {
-		add_filter( 'authenticate',           array( __CLASS__, 'authenticate' ), 10, 3 );
-		add_action( 'show_user_profile',      array( __CLASS__, 'show_user_profile' ) );
-		add_action( 'edit_user_profile',      array( __CLASS__, 'show_user_profile' ) );
-		add_action( 'rest_api_init',          array( __CLASS__, 'rest_api_init' ) );
+		add_filter( 'authenticate', array( __CLASS__, 'authenticate' ), 10, 3 );
+		add_action( 'show_user_profile', array( __CLASS__, 'show_user_profile' ) );
+		add_action( 'edit_user_profile', array( __CLASS__, 'show_user_profile' ) );
+		add_action( 'rest_api_init', array( __CLASS__, 'rest_api_init' ) );
 		add_filter( 'determine_current_user', array( __CLASS__, 'rest_api_auth_handler' ), 20 );
-		add_filter( 'wp_rest_server_class',   array( __CLASS__, 'wp_rest_server_class' ) );
-		add_action( 'admin_menu',             array( __CLASS__, 'admin_menu' ) );
+		add_filter( 'wp_rest_server_class', array( __CLASS__, 'wp_rest_server_class' ) );
+		add_action( 'admin_menu', array( __CLASS__, 'admin_menu' ) );
 		add_action( 'admin_post_authorize_application_password', array( __CLASS__, 'authorize_application_password' ) );
 		self::fallback_populate_username_password();
 	}
@@ -55,9 +55,9 @@ class Application_Passwords {
 	public static function wp_rest_server_class( $class ) {
 		global $current_user;
 		if ( defined( 'REST_REQUEST' )
-		     && REST_REQUEST
-		     && $current_user instanceof WP_User
-		     && 0 === $current_user->ID ) {
+			 && REST_REQUEST
+			 && $current_user instanceof WP_User
+			 && 0 === $current_user->ID ) {
 			/*
 			 * For our authentication to work, we need to remove the cached lack
 			 * of a current user, so the next time it checks, we can detect that
@@ -395,24 +395,28 @@ class Application_Passwords {
 	 * Page for authorizing applications.
 	 */
 	public static function auth_app_page() {
-		$app_name    = ! empty( $_GET['app_name'] )    ? $_GET['app_name']    : '';
+		$app_name    = ! empty( $_GET['app_name'] ) ? $_GET['app_name'] : '';
 		$success_url = ! empty( $_GET['success_url'] ) ? $_GET['success_url'] : null;
-		$reject_url  = ! empty( $_GET['reject_url'] )  ? $_GET['reject_url']  : $success_url;
+		$reject_url  = ! empty( $_GET['reject_url'] ) ? $_GET['reject_url'] : $success_url;
 		$user        = wp_get_current_user();
 
 		wp_enqueue_script( 'auth-app', plugin_dir_url( __FILE__ ) . 'auth-app.js', array() );
-		wp_localize_script( 'auth-app', 'authApp', array(
-			'root'       => esc_url_raw( rest_url() ),
-			'namespace'  => '2fa/v1',
-			'nonce'      => wp_create_nonce( 'wp_rest' ),
-			'user_id'    => $user->ID,
-			'user_login' => $user->user_login,
-			'success'    => $success_url,
-			'reject'     => $reject_url ? $reject_url : admin_url(),
-			'strings'    => array(
-				'new_pass' => esc_html_x( 'Your new password for %1$s is: %2$s', 'application, password' ),
-			),
-		) );
+		wp_localize_script(
+			'auth-app',
+			'authApp',
+			array(
+				'root'       => esc_url_raw( rest_url() ),
+				'namespace'  => '2fa/v1',
+				'nonce'      => wp_create_nonce( 'wp_rest' ),
+				'user_id'    => $user->ID,
+				'user_login' => $user->user_login,
+				'success'    => $success_url,
+				'reject'     => $reject_url ? $reject_url : admin_url(),
+				'strings'    => array(
+					'new_pass' => esc_html_x( 'Your new password for %1$s is: %2$s', 'application, password' ),
+				),
+			)
+		);
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Authorize Application' ); ?></h1>

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -391,6 +391,8 @@ class Application_Passwords {
 	 *
 	 */
 	public static function authorize_application_password() {
+		check_admin_referer( 'authorize_application_password' );
+
 		$success_url = $_POST['success_url'];
 		$reject_url  = $_POST['reject_url'];
 		$app_name    = $_POST['app_name'];

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -322,7 +322,7 @@ class Application_Passwords {
 	 * Page for authorizing applications.
 	 */
 	public static function auth_app_page() {
-		$title       = ! empty( $_GET['title'] )       ? $_GET['title']       : 'Sparkly Pants';
+		$app_name    = ! empty( $_GET['app_name'] )    ? $_GET['app_name']    : 'Sparkly Pants';
 		$success_url = ! empty( $_GET['success_url'] ) ? $_GET['success_url'] : null;
 		$reject_url  = ! empty( $_GET['reject_url'] )  ? $_GET['reject_url']  : null;
 		?>
@@ -331,11 +331,11 @@ class Application_Passwords {
 
 			<div class="card">
 				<h2 class="title"><?php esc_html_e( 'An application would like to connect to your account.' ); ?></h2>
-				<p><?php printf( esc_html__( 'Would you like to give the application identifying itself as %1$s access to your account?  You should only do this if you trust the app in question.' ), '<strong>' . esc_html( $title ) . '</strong>' ); ?></p>
+				<p><?php printf( esc_html__( 'Would you like to give the application identifying itself as %1$s access to your account?  You should only do this if you trust the app in question.' ), '<strong>' . esc_html( $app_name ) . '</strong>' ); ?></p>
 				<form action="#">
 
-					<label for="app_title"><?php esc_html_e( 'Application Title:' ); ?></label>
-					<input type="text" id="app_title" name="app_title" value="<?php echo esc_attr( $title ); ?>" />
+					<label for="app_name"><?php esc_html_e( 'Application Title:' ); ?></label>
+					<input type="text" id="app_name" name="app_name" value="<?php echo esc_attr( $app_name ); ?>" />
 
 					<p><?php submit_button( __( 'Yes, I approve of this connection.' ), 'primary', 'approve', false ); ?>
 						<br /><em>

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -426,11 +426,11 @@ class Application_Passwords {
 				<h2 class="title"><?php esc_html_e( 'An application would like to connect to your account.' ); ?></h2>
 				<?php if ( $app_name ) : ?>
 					<p>
-                    <?php
-                    // translators: application name
-                    printf( esc_html__( 'Would you like to give the application identifying itself as %1$s access to your account?  You should only do this if you trust the app in question.' ), '<strong>' . esc_html( $app_name ) . '</strong>' );
-                    ?>
-                    </p>
+					<?php
+					// translators: application name
+					printf( esc_html__( 'Would you like to give the application identifying itself as %1$s access to your account?  You should only do this if you trust the app in question.' ), '<strong>' . esc_html( $app_name ) . '</strong>' );
+					?>
+					</p>
 				<?php else : ?>
 					<p><?php esc_html_e( 'Would you like to give this application access to your account?  You should only do this if you trust the app in question.' ); ?></p>
 				<?php endif; ?>
@@ -447,46 +447,46 @@ class Application_Passwords {
 						<br /><em>
 						<?php
 						if ( $success_url ) {
-                            // translators: url
+							// translators: url
 							printf(
-                                esc_html_x( 'You will be sent to %1$s', '%1$s is a url' ),
-                                '<strong><kbd>' . esc_html(
-                                    add_query_arg(
-							            array(
-                                            'username' => $user->user_login,
-                                            'password' => '[------]'
-                                        ),
-                                        $success_url
-                                    )
-                                ) . '</kbd></strong>'
-                            );
+								esc_html_x( 'You will be sent to %1$s', '%1$s is a url' ),
+								'<strong><kbd>' . esc_html(
+									add_query_arg(
+										array(
+											'username' => $user->user_login,
+											'password' => '[------]'
+										),
+										$success_url
+									)
+								) . '</kbd></strong>'
+							);
 						} else {
 							esc_html_e( 'You will be given a password to manually enter into the application in question.' );
 						}
-                        ?>
+						?>
 						</em>
 					</p>
 
 					<p><?php submit_button( __( 'No, I do not approve of this connection.' ), 'secondary', 'reject', false ); ?>
 						<br /><em>
 						<?php
-                        if ( $reject_url ) {
-                            // translators: url
-                            printf(
-                                esc_html_x( 'You will be sent to %1$s', '%1$s is a url' ),
-                                '<strong><kbd>' . esc_html(
-                                    add_query_arg(
-                                        array(
-                                            'success' => 'false'
-                                        ),
-                                        $reject_url
-                                    )
-                                ) . '</kbd></strong>'
-                            );
+						if ( $reject_url ) {
+							// translators: url
+							printf(
+								esc_html_x( 'You will be sent to %1$s', '%1$s is a url' ),
+								'<strong><kbd>' . esc_html(
+									add_query_arg(
+										array(
+											'success' => 'false'
+										),
+										$reject_url
+									)
+								) . '</kbd></strong>'
+							);
 						} else {
 							esc_html_e( 'You will be returned to the WordPress Dashboard, and we will never speak of this again.' );
-                        }
-                        ?>
+						}
+						?>
 						</em>
 					</p>
 

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -55,9 +55,9 @@ class Application_Passwords {
 	public static function wp_rest_server_class( $class ) {
 		global $current_user;
 		if ( defined( 'REST_REQUEST' )
-			 && REST_REQUEST
-			 && $current_user instanceof WP_User
-			 && 0 === $current_user->ID ) {
+			&& REST_REQUEST
+			&& $current_user instanceof WP_User
+			&& 0 === $current_user->ID ) {
 			/*
 			 * For our authentication to work, we need to remove the cached lack
 			 * of a current user, so the next time it checks, we can detect that
@@ -413,6 +413,7 @@ class Application_Passwords {
 				'success'    => $success_url,
 				'reject'     => $reject_url ? $reject_url : admin_url(),
 				'strings'    => array(
+                    // translators: application, password
 					'new_pass' => esc_html_x( 'Your new password for %1$s is: %2$s', 'application, password' ),
 				),
 			)

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -427,7 +427,7 @@ class Application_Passwords {
 				<?php if ( $app_name ) : ?>
 					<p>
 					<?php
-					// translators: application name
+					// translators: application name.
 					printf( esc_html__( 'Would you like to give the application identifying itself as %1$s access to your account?  You should only do this if you trust the app in question.' ), '<strong>' . esc_html( $app_name ) . '</strong>' );
 					?>
 					</p>
@@ -447,14 +447,14 @@ class Application_Passwords {
 						<br /><em>
 						<?php
 						if ( $success_url ) {
-							// translators: url
 							printf(
+								// translators: url.
 								esc_html_x( 'You will be sent to %1$s', '%1$s is a url' ),
 								'<strong><kbd>' . esc_html(
 									add_query_arg(
 										array(
 											'username' => $user->user_login,
-											'password' => '[------]'
+											'password' => '[------]',
 										),
 										$success_url
 									)
@@ -471,13 +471,13 @@ class Application_Passwords {
 						<br /><em>
 						<?php
 						if ( $reject_url ) {
-							// translators: url
 							printf(
+								// translators: url.
 								esc_html_x( 'You will be sent to %1$s', '%1$s is a url' ),
 								'<strong><kbd>' . esc_html(
 									add_query_arg(
 										array(
-											'success' => 'false'
+											'success' => 'false',
 										),
 										$reject_url
 									)
@@ -526,7 +526,7 @@ class Application_Passwords {
 			);
 		}
 
-		wp_redirect( $redirect );
+		wp_redirect( $redirect ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 		exit;
 
 	}
@@ -546,15 +546,19 @@ class Application_Passwords {
 	public static function show_user_profile( $user ) {
 		wp_enqueue_style( 'application-passwords-css', plugin_dir_url( __FILE__ ) . 'application-passwords.css', array(), APPLICATION_PASSWORDS_VERSION );
 		wp_enqueue_script( 'application-passwords-js', plugin_dir_url( __FILE__ ) . 'application-passwords.js', array(), APPLICATION_PASSWORDS_VERSION, true );
-		wp_localize_script( 'application-passwords-js', 'appPass', array(
-			'root'       => esc_url_raw( rest_url() ),
-			'namespace'  => '2fa/v1',
-			'nonce'      => wp_create_nonce( 'wp_rest' ),
-			'user_id'    => $user->ID,
-			'text'       => array(
-				'no_credentials' => __( 'Due to a potential server misconfiguration, it seems that HTTP Basic Authorization may not work for the REST API on this site: `Authorization` headers are not being sent to WordPress by the web server. <a href="https://github.com/georgestephanis/application-passwords/wiki/Basic-Authorization-Header----Missing">You can learn more about this problem, and a possible solution, on our GitHub Wiki.</a>' ),
-			),
-		) );
+		wp_localize_script(
+			'application-passwords-js',
+			'appPass',
+			array(
+				'root'       => esc_url_raw( rest_url() ),
+				'namespace'  => '2fa/v1',
+				'nonce'      => wp_create_nonce( 'wp_rest' ),
+				'user_id'    => $user->ID,
+				'text'       => array(
+					'no_credentials' => __( 'Due to a potential server misconfiguration, it seems that HTTP Basic Authorization may not work for the REST API on this site: `Authorization` headers are not being sent to WordPress by the web server. <a href="https://github.com/georgestephanis/application-passwords/wiki/Basic-Authorization-Header----Missing">You can learn more about this problem, and a possible solution, on our GitHub Wiki.</a>' ),
+				),
+			)
+		);
 
 		?>
 		<div class="application-passwords hide-if-no-js" id="application-passwords-section">

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -325,11 +325,26 @@ class Application_Passwords {
 		$app_name    = ! empty( $_GET['app_name'] )    ? $_GET['app_name']    : 'Sparkly Pants';
 		$success_url = ! empty( $_GET['success_url'] ) ? $_GET['success_url'] : null;
 		$reject_url  = ! empty( $_GET['reject_url'] )  ? $_GET['reject_url']  : null;
+		$user        = wp_get_current_user();
+
+		wp_enqueue_script( 'auth-app', plugin_dir_url( __FILE__ ) . 'auth-app.js', array() );
+		wp_localize_script( 'auth-app', 'authApp', array(
+			'root'       => esc_url_raw( rest_url() ),
+			'namespace'  => '2fa/v1',
+			'nonce'      => wp_create_nonce( 'wp_rest' ),
+			'user_id'    => $user->ID,
+			'user_login' => $user->user_login,
+			'success'    => $success_url,
+			'reject'     => $reject_url ? $reject_url : admin_url(),
+			'strings'    => array(
+				'new_pass' => esc_html_x( 'Your new password for %1$s is: %2$s', 'application, password' ),
+			)
+		) );
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Authorize Application' ); ?></h1>
 
-			<div class="card">
+			<div class="card js-auth-app-card">
 				<h2 class="title"><?php esc_html_e( 'An application would like to connect to your account.' ); ?></h2>
 				<p><?php printf( esc_html__( 'Would you like to give the application identifying itself as %1$s access to your account?  You should only do this if you trust the app in question.' ), '<strong>' . esc_html( $app_name ) . '</strong>' ); ?></p>
 				<form action="#">

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -427,7 +427,7 @@ class Application_Passwords {
 					<input type="hidden" name="reject_url" value="<?php echo esc_url( $reject_url ); ?>" />
 
 					<label for="app_name"><?php esc_html_e( 'Application Title:' ); ?></label>
-					<input type="text" id="app_name" name="app_name" value="<?php echo esc_attr( $app_name ); ?>" />
+					<input type="text" id="app_name" name="app_name" value="<?php echo esc_attr( $app_name ); ?>" placeholder="<?php esc_attr_e( 'Name this connection&hellip;' ); ?>" required />
 
 					<p><?php submit_button( __( 'Yes, I approve of this connection.' ), 'primary', 'approve', false ); ?>
 						<br /><em>

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -550,11 +550,11 @@ class Application_Passwords {
 			'application-passwords-js',
 			'appPass',
 			array(
-				'root'       => esc_url_raw( rest_url() ),
-				'namespace'  => '2fa/v1',
-				'nonce'      => wp_create_nonce( 'wp_rest' ),
-				'user_id'    => $user->ID,
-				'text'       => array(
+				'root' => esc_url_raw( rest_url() ),
+				'namespace' => '2fa/v1',
+				'nonce' => wp_create_nonce( 'wp_rest' ),
+				'user_id' => $user->ID,
+				'text' => array(
 					'no_credentials' => __( 'Due to a potential server misconfiguration, it seems that HTTP Basic Authorization may not work for the REST API on this site: `Authorization` headers are not being sent to WordPress by the web server. <a href="https://github.com/georgestephanis/application-passwords/wiki/Basic-Authorization-Header----Missing">You can learn more about this problem, and a possible solution, on our GitHub Wiki.</a>' ),
 				),
 			)

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -413,7 +413,7 @@ class Application_Passwords {
 				'success'    => $success_url,
 				'reject'     => $reject_url ? $reject_url : admin_url(),
 				'strings'    => array(
-                    // translators: application, password
+					// translators: application, password
 					'new_pass' => esc_html_x( 'Your new password for %1$s is: %2$s', 'application, password' ),
 				),
 			)
@@ -441,10 +441,7 @@ class Application_Passwords {
 					<p><?php submit_button( __( 'Yes, I approve of this connection.' ), 'primary', 'approve', false ); ?>
 						<br /><em>
 						<?php if ( $success_url ) : ?>
-							<?php printf( esc_html_x( 'You will be sent to %1$s', '%1$s is a url' ), '<strong><tt>' . esc_html( add_query_arg( array(
-								'username' => $user->user_login,
-								'password' => '[------]',
-							), $success_url ) ) . '</tt></strong>' ); ?>
+							<?php printf( esc_html_x( 'You will be sent to %1$s', '%1$s is a url' ), '<strong><tt>' . esc_html( add_query_arg( array( 'username' => $user->user_login, 'password' => '[------]' ), $success_url ) ) . '</tt></strong>' ); ?>
 						<?php else : ?>
 							<?php esc_html_e( 'You will be given a password to manually enter into the application in question.' ); ?>
 						<?php endif; ?>
@@ -488,10 +485,13 @@ class Application_Passwords {
 			if ( empty( $success_url ) ) {
 				wp_die( '<h1>' . esc_html__( 'Your New Application Password:' ) . '</h1><h3><kbd>' . esc_html( self::chunk_password( $new_password ) ) . '</kbd></h3>' );
 			}
-			$redirect = add_query_arg( array(
-				'username' => wp_get_current_user()->user_login,
-				'password' => $new_password,
-			), $success_url );
+			$redirect = add_query_arg(
+				array(
+					'username' => wp_get_current_user()->user_login,
+					'password' => $new_password,
+				),
+				$success_url
+			);
 		}
 
 		wp_redirect( $redirect );
@@ -551,6 +551,7 @@ class Application_Passwords {
 						<div class="new-application-password-content">
 							<?php
 							printf(
+								// translators: application, password
 								esc_html_x( 'Your new password for %1$s is: %2$s', 'application, password' ),
 								'<strong>{{ data.name }}</strong>',
 								'<kbd>{{ data.password }}</kbd>'

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -395,7 +395,7 @@ class Application_Passwords {
 	 * Page for authorizing applications.
 	 */
 	public static function auth_app_page() {
-		$app_name    = ! empty( $_GET['app_name'] )    ? $_GET['app_name']    : 'Sparkly Pants';
+		$app_name    = ! empty( $_GET['app_name'] )    ? $_GET['app_name']    : '';
 		$success_url = ! empty( $_GET['success_url'] ) ? $_GET['success_url'] : null;
 		$reject_url  = ! empty( $_GET['reject_url'] )  ? $_GET['reject_url']  : $success_url;
 		$user        = wp_get_current_user();

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -32,7 +32,7 @@ class Application_Passwords {
 	public static function add_hooks() {
 		add_filter( 'authenticate',           array( __CLASS__, 'authenticate' ), 10, 3 );
 		add_action( 'show_user_profile',      array( __CLASS__, 'show_user_profile' ) );
-		add_action( 'edit_user_profile',	    array( __CLASS__, 'show_user_profile' ) );
+		add_action( 'edit_user_profile',      array( __CLASS__, 'show_user_profile' ) );
 		add_action( 'rest_api_init',          array( __CLASS__, 'rest_api_init' ) );
 		add_filter( 'determine_current_user', array( __CLASS__, 'rest_api_auth_handler' ), 20 );
 		add_filter( 'wp_rest_server_class',   array( __CLASS__, 'wp_rest_server_class' ) );

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -333,32 +333,32 @@ class Application_Passwords {
 				<h2 class="title"><?php esc_html_e( 'An application would like to connect to your account.' ); ?></h2>
 				<p><?php printf( esc_html__( 'Would you like to give the application identifying itself as %1$s access to your account?  You should only do this if you trust the app in question.' ), '<strong>' . esc_html( $title ) . '</strong>' ); ?></p>
 				<form action="#">
-					<?php
-					echo '<label for="app_title">' . esc_html__( 'Application Title:' ) . '</label> ';
-					printf( '<input type="text" id="app_title" name="app_title" value="%1$s" />', esc_attr( $title ) );
 
-					echo '<p>';
-					submit_button( __( 'Yes, I approve of this connection.' ), 'primary', 'approve', false );
-					echo '<br /><em>';
-					if ( $success_url ) {
-						printf( '<input type="hidden" name="success_url" value="%1$s" />', esc_url( $success_url ) );
-						printf( esc_html__( 'You will be sent to %1$s' ), '<strong><tt>' . esc_html( $success_url ) . '</tt></strong>' );
-					} else {
-						esc_html_e( 'You will be given a password to manually enter into the application in question.' );
-					}
-					echo '</em></p>';
+					<label for="app_title"><?php esc_html_e( 'Application Title:' ); ?></label>
+					<input type="text" id="app_title" name="app_title" value="<?php echo esc_attr( $title ); ?>" />
 
-					echo '<p>';
-					submit_button( __( 'No, I do not approve of this connection.' ), 'secondary', 'reject', false );
-					echo '<br /><em>';
-					if ( $success_url ) {
-						printf( '<input type="hidden" name="reject_url" value="%1$s" />', esc_url( $reject_url ) );
-						printf( esc_html__( 'You will be sent to %1$s' ), '<strong><tt>' . esc_html( $reject_url ) . '</tt></strong>' );
-					} else {
-						esc_html_e( 'You will be returned to the WordPress Dashboard, and we will never speak of this again.' );
-					}
-					echo '</em></p>';
-					?>
+					<p><?php submit_button( __( 'Yes, I approve of this connection.' ), 'primary', 'approve', false ); ?>
+						<br /><em>
+						<?php if ( $success_url ) : ?>
+							<input type="hidden" name="success_url" value="<?php echo esc_url( $success_url ); ?>" />
+							<?php printf( esc_html_x( 'You will be sent to %1$s', '%1$s is a url' ), '<strong><tt>' . esc_html( $success_url ) . '</tt></strong>' ); ?>
+						<?php else: ?>
+							<?php esc_html_e( 'You will be given a password to manually enter into the application in question.' ); ?>
+						<?php endif; ?>
+						</em>
+					</p>
+
+					<p><?php submit_button( __( 'No, I do not approve of this connection.' ), 'secondary', 'reject', false ); ?>
+						<br /><em>
+						<?php if ( $reject_url ) : ?>
+							<input type="hidden" name="reject_url" value="<?php echo esc_url( $reject_url ); ?>" />
+							<?php printf( esc_html_x( 'You will be sent to %1$s', '%1$s is a url' ), '<strong><tt>' . esc_html( $reject_url ) . '</tt></strong>' ); ?>
+						<?php else : ?>
+							<?php esc_html_e( 'You will be returned to the WordPress Dashboard, and we will never speak of this again.' ); ?>
+						<?php endif; ?>
+						</em>
+					</p>
+
 				</form>
 			</div>
 		</div>

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -550,11 +550,11 @@ class Application_Passwords {
 			'application-passwords-js',
 			'appPass',
 			array(
-				'root' => esc_url_raw( rest_url() ),
+				'root'      => esc_url_raw( rest_url() ),
 				'namespace' => '2fa/v1',
-				'nonce' => wp_create_nonce( 'wp_rest' ),
-				'user_id' => $user->ID,
-				'text' => array(
+				'nonce'     => wp_create_nonce( 'wp_rest' ),
+				'user_id'   => $user->ID,
+				'text'      => array(
 					'no_credentials' => __( 'Due to a potential server misconfiguration, it seems that HTTP Basic Authorization may not work for the REST API on this site: `Authorization` headers are not being sent to WordPress by the web server. <a href="https://github.com/georgestephanis/application-passwords/wiki/Basic-Authorization-Header----Missing">You can learn more about this problem, and a possible solution, on our GitHub Wiki.</a>' ),
 				),
 			)

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,6 @@ This test uses the technologies listed below, but you can use any XML-RPC reques
 
 Once you have created a new application password, it's time to send a request to test it.  Unlike the WordPress REST API, XML-RPC does not require your username and password to be base64 encoded.  To begin the process, open a terminal window and enter the following:
 ```shell
-curl -H 'Content-Type: text/xml' -d '<methodCall><methodName>wp.getUsers</methodName><params><param><value>1</value></param><param><value>USERNAME</value></param><param><value>PASSWORD</value></param></params></methodCall>' LOCALHOST
+curl -H 'Content-Type: text/xml' -d '<methodCall><methodName>wp.getUsers</methodName><params><param><value>1</value></param><param><value>USERNAME</value></param><param><value>APPLICATION_PASSWORD</value></param></params></methodCall>' LOCALHOST
 ```
-In the above example, replace *USERNAME* with your username, and *PASSWORD* with your new application password.  This should output a response containing all users on your site.
+In the above example, replace *USERNAME* with your username, and *APPLICATION_PASSWORD* with your new application password.  This should output a response containing all users on your site.

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,18 @@ With Application Passwords you are able to authenticate a user without providing
 
 == Creating a New Application Password ==
 
+### For an application to get a user to generate an application password:
+
+Direct the user to `http://example.com/wp-admin/admin.php?page=auth_app`
+
+The following GET variables are supported currently to append to ^^ that url
+
+- `app_name` - ( required-ish ) - The human readable identifier for your app.  This will be the name of the generated application password, so structure it like ... "WordPress Mobile App on iPhone 5" for uniqueness between multiple versions.  If omitted, the user will be required to provide an application name.
+- `success_url` - ( recommended ) - The URL that you'd like the user to be sent to if they approve the connection.  Two GET variables will be appended when they are passed back -- `user_login` and `password` -- these credentials can then be used for API calls.  If the `success_url` variable is omitted, a password will be generated and displayed to the user, to manually enter into your application.
+- `reject_url` - ( optional ) - If included, the user will get sent there if they reject the connection.  If omitted, the user will be sent to the `success_url`, with `?success=false` appended to the end.  If the `success_url` is omitted, the user will be sent to their dashboard.
+
+### For a user to manually generate an application password:
+
 1. Go the User Profile page of the user that you want to generate a new application password for.  To do so, click *Users* on the left side of the WordPress admin, then click on the user that you want to manage.
 2. Scroll down until you see the Application Passwords section.  This is typically at the bottom of the page.
 3. Within the input field, type in a name for your new application password, then click *Add New*.

--- a/readme.txt
+++ b/readme.txt
@@ -61,21 +61,11 @@ This test uses the technologies listed below, but you can use any REST API reque
 * A Mac or Linux terminal
 * Local development environment (e.g. MAMP, XAMPP, DesktopServer, Vagrant) running on localhost
 
-1. Now that you have your new password, you will need to base64 encode it using a terminal window as well as your username to use it with the REST API.
-   The command you will use is as follows:
+1. Now that you have your new password, you are now able to make a simple REST API call using the terminal window to update a post. If authorized correctly, you will see the post title update to "New Title."
 ```shell
-echo -n "USERNAME:PASSWORD" | base64
+curl --user "USERNAME:APPLICATION_PASSWORD" -X POST -d "title=New Title" http://LOCALHOST/wp-json/wp/v2/posts/POST_ID
 ```
-   Within this, you will replace *USERNAME:PASSWORD* with your username and newly generated application password.  For example:
-```shell
-echo -n "admin:mypassword123" | base64
-```
-
-2. Once your username and password are base64 encoded, you are now able to make a simple REST API call using the terminal window to update a post.  Because you are performing a POST request, you will need to authorize the request using your newly created base64 encoded access token. If authorized correctly, you will see the post title update to "New Title."
-```shell
-curl --header "Authorization: Basic ACCESS_TOKEN" -X POST -d "title=New Title" http://LOCALHOST/wp-json/wp/v2/posts/POST_ID}
-```
-   When running this command, be sure to replace *ACCESS_TOKEN* with your newly generated access token, *LOCALHOST* with the location of your local WordPress installation, and *POST_ID* with the ID of the post that you want to edit.
+   When running this command, be sure to replace *USERNAME* and *APPLICATION_PASSWORD* with your credentials, *LOCALHOST* with the location of your local WordPress installation, and *POST_ID* with the ID of the post that you want to edit.
 
 ### XML-RPC
 


### PR DESCRIPTION
Mockup: https://cloudup.com/cXDserZRH_Y

Very much a work in progress, **_not yet ready for merging._**

The idea is to give a page in wp-admin where you can send a user, they can authenticate via wp-login.php if needed, then manually approve (or reject) it and it will send the user back to the app with an application password in tow that the app can store and use.

It saves the user from having to find their profile page and create and retype or copy/paste an application password.  Should be more understandable.

Fixes #36 
