### PR TITLE
Fixed bug in create new application password method

### DIFF
--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -407,7 +407,7 @@ class Application_Passwords {
 	 * @return array          The first key in the array is the new password, the second is its row in the table.
 	 */
 	public static function create_new_application_password( $user_id, $name ) {
-		$new_password    = wp_generate_password( SELF::PW_LENGTH, false );
+		$new_password    = wp_generate_password( self::PW_LENGTH, false );
 		$hashed_password = wp_hash_password( $new_password );
 
 		$new_item = array(


### PR DESCRIPTION
Changed SELF to self, which fixes fatal error when using HHVM 3.5.1, because SELF is seen as an undefined class.

This bug makes the plugin completely unusable on HHVM 3.5.l