### PR TITLE
SELF:: to self::

### DIFF
--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -407,7 +407,7 @@ class Application_Passwords {
 	 * @return array          The first key in the array is the new password, the second is its row in the table.
 	 */
 	public static function create_new_application_password( $user_id, $name ) {
-		$new_password    = wp_generate_password( SELF::PW_LENGTH, false );
+		$new_password    = wp_generate_password( self::PW_LENGTH, false );
 		$hashed_password = wp_hash_password( $new_password );
 
 		$new_item = array(


### PR DESCRIPTION
This plugin wouldn't run in my local environment before I made this change. I was getting `PHP Fatal error:  Class 'SELF' not found in \htdocs\test-site\wp-content\plugins\application-passwords-master\class.application-passwords.php on line 410`