### PR TITLE
Hook into `rest_authentication_errors` to authenticate REST requests

### DIFF
--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -72,9 +72,6 @@ class Application_Passwords {
 	 * @static
 	 */
 	public static function rest_api_init() {
-		#add_filter( 'determine_current_user',	array( __CLASS__, 'rest_api_auth_handler' ), 200 );
-		#add_filter( 'authenticate',		array( __CLASS__, 'authenticate' ), 10, 3 );
-
 		// List existing application passwords
 		register_rest_route( '2fa/v1', '/application-passwords/(?P<user_id>[\d]+)', array(
 			'methods' => WP_REST_Server::READABLE,

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -40,8 +40,8 @@ class Application_Passwords {
 	/**
 	 * Check authentication of REST API calls
 	 *
-	 * @param WP_Error|null|bool WP_Error if authentication error, null if authentication
-	 *                              method wasn't used, true if authentication succeeded.
+	 * @param WP_Error|null|bool $result WP_Error if authentication error, null if authentication
+	 *                                      method wasn't used, true if authentication succeeded.
 	 * @return WP_Error|null|bool
 	 */
 	public static function rest_authenticate( $result ) {

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -29,12 +29,12 @@ class Application_Passwords {
 	 * @access public
 	 * @static
 	 */
-	 public static function add_hooks() {
- 		add_filter( 'authenticate',		array( __CLASS__, 'authenticate' ), 10, 3 );
- 		add_action( 'show_user_profile',	array( __CLASS__, 'show_user_profile' ) );
- 		add_action( 'rest_api_init',		array( __CLASS__, 'rest_api_init' ) );
- 		add_filter( 'determine_current_user',	array( __CLASS__, 'rest_api_auth_handler' ), 20 );
- 		add_filter( 'rest_authentication_errors', array( __CLASS__, 'rest_authenticate' ) );
+	public static function add_hooks() {
+		add_filter( 'authenticate',               array( __CLASS__, 'authenticate' ), 10, 3 );
+		add_action( 'show_user_profile',          array( __CLASS__, 'show_user_profile' ) );
+		add_action( 'rest_api_init',              array( __CLASS__, 'rest_api_init' ) );
+		add_filter( 'determine_current_user',     array( __CLASS__, 'rest_api_auth_handler' ), 20 );
+		add_filter( 'rest_authentication_errors', array( __CLASS__, 'rest_authenticate' ) );
 	}
 
 	/**

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -57,6 +57,8 @@ class Application_Passwords {
 		$user = self::authenticate( null, $_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'] );
 
 		if ( $user instanceof WP_User ) {
+			wp_set_current_user( $user->ID );
+
 			return true;
 		}
 

--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -35,7 +35,6 @@ class Application_Passwords {
  		add_action( 'rest_api_init',		array( __CLASS__, 'rest_api_init' ) );
  		add_filter( 'determine_current_user',	array( __CLASS__, 'rest_api_auth_handler' ), 20 );
  		add_filter( 'rest_authentication_errors', array( __CLASS__, 'rest_authenticate' ) );
- 		#add_filter( 'wp_rest_server_class',	array( __CLASS__, 'wp_rest_server_class' ) );
 	}
 
 	/**
@@ -62,35 +61,6 @@ class Application_Passwords {
 		}
 
 		return $result;
-	}
-
-	/**
-	 * Prevent caching of unauthenticated status.  See comment below.
-	 *
-	 * We don't actually care about the `wp_rest_server_class` filter, it just
-	 * happens right after the constant we do care about is defined.
-	 *
-	 * @since 0.1-dev
-	 *
-	 * @access public
-	 * @static
-	 */
-	public static function wp_rest_server_class( $class ) {
-		global $current_user;
-		if ( defined( 'REST_REQUEST' )
-		     && REST_REQUEST
-		     && $current_user instanceof WP_User
-		     && 0 === $current_user->ID ) {
-			/*
-			 * For our authentication to work, we need to remove the cached lack
-			 * of a current user, so the next time it checks, we can detect that
-			 * this is a rest api request and allow our override to happen.  This
-			 * is because the constant is defined later than the first get current
-			 * user call may run.
-			 */
-			$current_user = null;
-		}
-		return $class;
 	}
 
 	/**


### PR DESCRIPTION
I was trying to make an authenticated REST request with [Minnie](https://github.com/kucrut/minnie) and found a fact that when the request contains login cookies, the authentication always fails, eventhough the correct username and app password were sent.

_Quick info about Minnie:_
Both the WordPress backend and frontend (Minnie) are served on the same domain, so when you're logged in, REST requests done by Minnie will always contain the login cookies.

As it turns out, `Application_Passwords::rest_api_auth_handler()` will (correctly) bail when the current user is already set (because WP detected the login cookies) but then `rest_cookie_check_errors()` "resets" it because the request doesn't send a nonce.

This PR fixes this issue by hooking into `rest_authentication_errors` to do the authentication.

Please review. Any feedback would be greatly appreciated!
