### PR TITLE
Don't loop through a string

### DIFF
--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -294,7 +294,7 @@ class Application_Passwords {
 		 */
 		$password = preg_replace( '/[^a-z\d]/i', '', $password );
 
-		$hashed_passwords = get_user_meta( $user->ID, self::USERMETA_KEY_APPLICATION_PASSWORDS, true );
+		$hashed_passwords = get_user_meta( $user->ID, self::USERMETA_KEY_APPLICATION_PASSWORDS );
 
 		foreach ( $hashed_passwords as $key => $item ) {
 			if ( wp_check_password( $password, $item['password'], $user->ID ) ) {


### PR DESCRIPTION
Removed 3rd parameter of `get_user_meta` to return Array instead of string, so that the following `foreach` can loop through the `$hashed_passwords` variable.