### PR TITLE
Sanity check on get_user_meta's return value

### DIFF
--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -295,6 +295,9 @@ class Application_Passwords {
 		$password = preg_replace( '/[^a-z\d]/i', '', $password );
 
 		$hashed_passwords = get_user_meta( $user->ID, self::USERMETA_KEY_APPLICATION_PASSWORDS, true );
+		if ( ! is_array( $hashed_passwords ) ) {
+			return $input_user;
+		}
 
 		foreach ( $hashed_passwords as $key => $item ) {
 			if ( wp_check_password( $password, $item['password'], $user->ID ) ) {


### PR DESCRIPTION
When the return value of line 297 is empty, it usually is represented as a string, which causes line 302 (formerly 299) to throw a PHP Notice. Proposed code addition checks the type of `$hashed_passwords` to ensure it's loopable.