### PR TITLE
Allow creation of app passwords on other users' accounts

### DIFF
--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -32,6 +32,7 @@ class Application_Passwords {
 	 public static function add_hooks() {
  		add_filter( 'authenticate',		array( __CLASS__, 'authenticate' ), 10, 3 );
  		add_action( 'show_user_profile',	array( __CLASS__, 'show_user_profile' ) );
+		add_action( 'edit_user_profile',	array( __CLASS__, 'show_user_profile' ) );
  		add_action( 'rest_api_init',		array( __CLASS__, 'rest_api_init' ) );
  		add_filter( 'determine_current_user',	array( __CLASS__, 'rest_api_auth_handler' ), 20 );
  		add_filter( 'wp_rest_server_class',	array( __CLASS__, 'wp_rest_server_class' ) );


### PR DESCRIPTION
The current `show_user_profile` hook is only fired when viewing/editing one's own profile.
If the current user can edit other user's, the current user should be able to add application passwords to other users.
