### PR TITLE
add filter to skip last used update

### DIFF
--- a/class.application-passwords.php
+++ b/class.application-passwords.php
@@ -373,7 +373,9 @@ class Application_Passwords {
 				$item['last_used'] = time();
 				$item['last_ip']   = $_SERVER['REMOTE_ADDR'];
 				$hashed_passwords[ $key ] = $item;
-				update_user_meta( $user->ID, self::USERMETA_KEY_APPLICATION_PASSWORDS, $hashed_passwords );
+				if(apply_filters('application_password_update_last_used', true)) {
+					update_user_meta( $user->ID, self::USERMETA_KEY_APPLICATION_PASSWORDS, $hashed_passwords );
+				}
 				return $user;
 			}
 		}


### PR DESCRIPTION
hey, thx for your plugin we really ❤️  it .  we are running a large news publisher platform, almost fully based on wp-json api - and therefore your plugin is the perfect fit.

however we had some database troubles, producing too many wp_postmeta updates.


this PR adds a filter so users of the plugin can disable the post_meta_update.


e.g:
```php
add_filter('application_password_update_last_used', "application_password_update_last_used", 10, 1);

function application_password_update_last_used($use) {
		return false;
}
```