### PR TITLE
Put back the latest docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Creates unique passwords for applications to authenticate users without revealin
 
 ## Install
 
-Install from the official [WordPress.org plugin repository](https://wordpress.org/plugins/application-passwords/) by searching for "Application Passwords" under "Plugins" &rarr; "Add New" in your WordPress dashboard.
+Install from the official [WordPress.org plugin repository](https://wordpress.org/plugins/application-passwords/) by searching for "Application Passwords" under "Plugins" → "Add New" in your WordPress dashboard.
 
 ### Install Using Composer
 

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Install from the official [WordPress.org plugin repository](https://wordpress.or
 
 ## Documentation
 
-See the [plugin description on WordPress.org](https://wordpress.org/plugins/application-passwords/).
+See the [readme.txt](readme.txt) for usage instructions.
 
 ### Development Environment
 

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,8 @@ Included is a local devolopment environment using [Docker](https://www.docker.co
 
 ## Contribute
 
-All contributions are welcome!
+- Translate the plugin [into your language](https://translate.wordpress.org/projects/wp-plugins/application-passwords/).
+- Report issues, suggest features and contribute code [on GitHub](https://github.com/georgestephanis/application-passwords).
 
 
 ## Credits

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,8 @@
 
 [![Build Status](https://travis-ci.org/georgestephanis/application-passwords.svg?branch=master)](https://travis-ci.org/georgestephanis/application-passwords)
 
-A WordPress plugin for creating dedicated passwords for applications using WordPress as you.
+Creates unique passwords for applications to authenticate users without revealing their main passwords.
+
 
 ## Install
 

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ Creates unique passwords for applications to authenticate users without revealin
 
 == Description ==
 
-With Application Passwords you are able to authenticate a user without providing that user's password directly, instead you will use a base64 encoded string of their username and a new application password.
+With Application Passwords you are able to authenticate users without providing their passwordsš directly. Instead, a unique password is generated for each application without revealing the user's main password. Application passwords can be revoked for each application individually.
 
 
 = Requesting Password for Application =

--- a/readme.txt
+++ b/readme.txt
@@ -19,7 +19,7 @@ With Application Passwords you are able to authenticate users without providing 
 
 To request a password for your application, redirect users to:
 
-	wp-admin/admin.php?page=auth_app
+	https://example.com/wp-admin/admin.php?page=auth_app
 
 and use the following `GET` request parameters to specify:
 

--- a/readme.txt
+++ b/readme.txt
@@ -79,12 +79,12 @@ This is a feature plugin that is a spinoff of the main [Two-Factor Authenticatio
 
 == Installation ==
 
-Search for "Application Passwords" under "Plugins" &rarr; "Add New" in your WordPress dashboard to install the plugin.
+Search for "Application Passwords" under "Plugins" → "Add New" in your WordPress dashboard to install the plugin.
 
 Or install it manually:
 
 1. Download the [plugin zip file](https://downloads.wordpress.org/plugin/application-passwords.zip).
-2. Go to *Plugins* &rarr; *Add New* in your WordPress admin.
+2. Go to *Plugins* → *Add New* in your WordPress admin.
 3. Click on the *Upload Plugin* button.
 4. Select the file you downloaded.
 5. Click *Install Plugin*.

--- a/readme.txt
+++ b/readme.txt
@@ -12,8 +12,6 @@ A feature plugin for core to provide Application Passwords
 
 == Description ==
 
-This is a feature plugin that is a spinoff of the main [Two-Factor Authentication plugin](https://github.com/georgestephanis/two-factor/).
-
 With Application Passwords you are able to authenticate a user without providing that user's password directly, instead you will use a base64 encoded string of their username and a new application password.
 
 == Requesting Password for Application ==
@@ -72,6 +70,10 @@ Once you have created a new application password, it's time to send a request to
     curl -H 'Content-Type: text/xml' -d '<methodCall><methodName>wp.getUsers</methodName><params><param><value>1</value></param><param><value>USERNAME</value></param><param><value>PASSWORD</value></param></params></methodCall>' LOCALHOST
 
 In the above example, replace `USERNAME` with your username, and `PASSWORD` with your new application password. This should output a response containing all users on your site.
+
+= Plugin History =
+
+This is a feature plugin that is a spinoff of the main [Two-Factor Authentication plugin](https://github.com/georgestephanis/two-factor/).
 
 
 == Installation ==

--- a/readme.txt
+++ b/readme.txt
@@ -15,6 +15,12 @@ Creates unique passwords for applications to authenticate users without revealin
 With Application Passwords you are able to authenticate users without providing their passwordsš directly. Instead, a unique password is generated for each application without revealing the user's main password. Application passwords can be revoked for each application individually.
 
 
+= Contribute =
+
+- Translate the plugin [into your language](https://translate.wordpress.org/projects/wp-plugins/application-passwords/).
+- Report issues, suggest features and contribute code [on GitHub](https://github.com/georgestephanis/application-passwords).
+
+
 = Requesting Password for Application =
 
 To request a password for your application, redirect users to:

--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,7 @@ This is a feature plugin that is a spinoff of the main Two-Factor Authentication
 
 With Application Passwords you are able to authenticate a user without providing that user's password directly, instead you will use a base64 encoded string of their username and a new application password.
 
-== Requesting Application Password ==
+== Requesting Password for Application ==
 
 To request a password for your application, redirect users to:
 

--- a/readme.txt
+++ b/readme.txt
@@ -51,21 +51,11 @@ This test uses the technologies listed below, but you can use any REST API reque
 * A Mac or Linux terminal
 * Local development environment (e.g. MAMP, XAMPP, DesktopServer, Vagrant) running on localhost
 
-Use application passwords with WordPress REST API to change a post title:
+Make a REST API call using the terminal window to update a post. Because you are performing a `POST` request, you will need to authorize the request using your newly created base64 encoded access token. If authorized correctly, you will see the post title update to "New Title."
 
-1. Now that you have your new password, you will need to base64 encode it using a terminal window as well as your username to use it with the REST API. The command you will use is as follows:
+    curl --user "USERNAME:APPLICATION_PASSWORD" -X POST -d "title=New Title" http://LOCALHOST/wp-json/wp/v2/posts/POST_ID
 
-        echo -n "USERNAME:PASSWORD" | base64
-
-    Within this, you will replace `USERNAME:PASSWORD` with your username and newly generated application password. For example:
-
-        echo -n "admin:mypassword123" | base64
-
-2. Once your username and password are base64 encoded, you are now able to make a simple REST API call using the terminal window to update a post. Because you are performing a `POST` request, you will need to authorize the request using your newly created base64 encoded access token. If authorized correctly, you will see the post title update to "New Title."
-
-        curl --header "Authorization: Basic ACCESS_TOKEN" -X POST -d "title=New Title" http://LOCALHOST/wp-json/wp/v2/posts/POST_ID
-
-    When running this command, be sure to replace `ACCESS_TOKEN` with your newly generated access token, `LOCALHOST` with the location of your local WordPress installation, and `POST_ID` with the ID of the post that you want to edit.
+When running this command, be sure to replace `USERNAME` and `APPLICATION_PASSWORD` with your credentials (curl takes care of base64 encoding and setting the `Authorization` header), `LOCALHOST` with the location of your local WordPress installation, and `POST_ID` with the ID of the post that you want to edit.
 
 ### XML-RPC
 

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,8 @@ Creates unique passwords for applications to authenticate users without revealin
 
 With Application Passwords you are able to authenticate a user without providing that user's password directly, instead you will use a base64 encoded string of their username and a new application password.
 
-== Requesting Password for Application ==
+
+= Requesting Password for Application =
 
 To request a password for your application, redirect users to:
 
@@ -29,7 +30,7 @@ and use the following `GET` request parameters to specify:
 - `reject_url` (optional) - If included, the user will get sent there if they reject the connection. If omitted, the user will be sent to the `success_url`, with `?success=false` appended to the end.  If the `success_url` is omitted, the user will be sent to their dashboard.
 
 
-== Creating Application Password Manually ==
+= Creating Application Password Manually =
 
 1. Go the User Profile page of the user that you want to generate a new application password for.  To do so, click *Users* on the left side of the WordPress admin, then click on the user that you want to manage.
 2. Scroll down until you see the Application Passwords section.  This is typically at the bottom of the page.
@@ -37,9 +38,9 @@ and use the following `GET` request parameters to specify:
    **Note:** The application password name is only used to describe your password for easy management later.  It will not affect your password in any way.  Be descriptive, as it will lead to easier management if you ever need to change it later.
 4. Once the *Add New* button is clicked, your new application password will appear.  Be sure to keep this somewhere safe, as it will not be displayed to you again.  If you lose this password, it cannot be obtained again.
 
-== Testing an Application Password ==
+= Testing an Application Password ==
 
-### WordPress REST API
+#### WordPress REST API
 
 This test uses the technologies listed below, but you can use any REST API request.
 
@@ -55,7 +56,7 @@ Make a REST API call using the terminal window to update a post. Because you are
 
 When running this command, be sure to replace `USERNAME` and `APPLICATION_PASSWORD` with your credentials (curl takes care of base64 encoding and setting the `Authorization` header), `LOCALHOST` with the location of your local WordPress installation, and `POST_ID` with the ID of the post that you want to edit.
 
-### XML-RPC
+#### XML-RPC
 
 This test uses the technologies listed below, but you can use any XML-RPC request.
 

--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,22 @@ This is a feature plugin that is a spinoff of the main Two-Factor Authentication
 
 With Application Passwords you are able to authenticate a user without providing that user's password directly, instead you will use a base64 encoded string of their username and a new application password.
 
-== Creating a New Application Password ==
+== Requesting Application Password ==
+
+To request a password for your application, redirect users to:
+
+	wp-admin/admin.php?page=auth_app
+
+and use the following `GET` request parameters to specify:
+
+- `app_name` (required) - The human readable identifier for your app. This will be the name of the generated application password, so structure it like ... "WordPress Mobile App on iPhone 5" for uniqueness between multiple versions.  If omitted, the user will be required to provide an application name.
+
+- `success_url` (recommended) - The URL that you'd like the user to be sent to if they approve the connection. Two GET variables will be appended when they are passed back -- `user_login` and `password` -- these credentials can then be used for API calls. If the `success_url` variable is omitted, a password will be generated and displayed to the user, to manually enter into your application.
+
+- `reject_url` (optional) - If included, the user will get sent there if they reject the connection. If omitted, the user will be sent to the `success_url`, with `?success=false` appended to the end.  If the `success_url` is omitted, the user will be sent to their dashboard.
+
+
+== Creating Application Password Manually ==
 
 1. Go the User Profile page of the user that you want to generate a new application password for.  To do so, click *Users* on the left side of the WordPress admin, then click on the user that you want to manage.
 2. Scroll down until you see the Application Passwords section.  This is typically at the bottom of the page.

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ A feature plugin for core to provide Application Passwords
 
 == Description ==
 
-This is a feature plugin that is a spinoff of the main Two-Factor Authentication plugin, found at https://github.com/georgestephanis/two-factor/.
+This is a feature plugin that is a spinoff of the main [Two-Factor Authentication plugin](https://github.com/georgestephanis/two-factor/).
 
 With Application Passwords you are able to authenticate a user without providing that user's password directly, instead you will use a base64 encoded string of their username and a new application password.
 

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,12 @@ In the above example, replace `USERNAME` with your username, and `PASSWORD` with
 5. Click *Install Plugin*.
 6. Activate.
 
+= Using Composer =
+
+Add this plugin as a [Composer](https://getcomposer.org) dependency [from Packagist](https://packagist.org/packages/georgestephanis/application-passwords):
+
+    composer require georgestephanis/application-passwords
+
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,11 +23,11 @@ To request a password for your application, redirect users to:
 
 and use the following `GET` request parameters to specify:
 
-- `app_name` (required) - The human readable identifier for your app. This will be the name of the generated application password, so structure it like ... "WordPress Mobile App on iPhone 5" for uniqueness between multiple versions.  If omitted, the user will be required to provide an application name.
+- `app_name` (required) - The human readable identifier for your app. This will be the name of the generated application password, so structure it like ... "WordPress Mobile App on iPhone 12" for uniqueness between multiple versions. If omitted, the user will be required to provide an application name.
 
 - `success_url` (recommended) - The URL that you'd like the user to be sent to if they approve the connection. Two GET variables will be appended when they are passed back -- `user_login` and `password` -- these credentials can then be used for API calls. If the `success_url` variable is omitted, a password will be generated and displayed to the user, to manually enter into your application.
 
-- `reject_url` (optional) - If included, the user will get sent there if they reject the connection. If omitted, the user will be sent to the `success_url`, with `?success=false` appended to the end.  If the `success_url` is omitted, the user will be sent to their dashboard.
+- `reject_url` (optional) - If included, the user will get sent there if they reject the connection. If omitted, the user will be sent to the `success_url`, with `?success=false` appended to the end. If the `success_url` is omitted, the user will be sent to their dashboard.
 
 
 = Creating Application Password Manually =

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Stable tag: trunk
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-A feature plugin for core to provide Application Passwords
+Creates unique passwords for applications to authenticate users without revealing their main passwords.
 
 
 == Description ==

--- a/readme.txt
+++ b/readme.txt
@@ -78,10 +78,14 @@ This is a feature plugin that is a spinoff of the main [Two-Factor Authenticatio
 
 == Installation ==
 
-1. Download the zip file.
-2. Log into WordPress, hover over *Plugins*, and click *Add New*.
+Search for "Application Passwords" under "Plugins" &rarr; "Add New" in your WordPress dashboard to install the plugin.
+
+Or install it manually:
+
+1. Download the [plugin zip file](https://downloads.wordpress.org/plugin/application-passwords.zip).
+2. Go to *Plugins* &rarr; *Add New* in your WordPress admin.
 3. Click on the *Upload Plugin* button.
-4. Select the zip file you downloaded.
+4. Select the file you downloaded.
 5. Click *Install Plugin*.
 6. Activate.
 


### PR DESCRIPTION
- [x] Add back the instructions for how apps can request passwords.
- [x] Update the REST API example to use `curl` for encoding the password.