### PR TITLE
Document Two Factor support

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -17,10 +17,30 @@ Use Application Passwords to authenticate users without providing their password
 **Important:** Application Passwords can be used only for authenticating API requests and they won't work for regular login.
 
 
+= Two Factor Support =
+
+Application Passwords can be used together with the [Two Factor plugin](https://wordpress.org/plugins/two-factor/) as long as you disable the extra protection added by the Two Factor plugin which disables API requests with password authentication _for users with Two Factor enabled_.
+
+Use the `two_factor_user_api_login_enable` filter to allow API requests with password-based authentication header for all users:
+
+    add_filter( 'two_factor_user_api_login_enable', '__return_true' );
+
+This is not required if the user associated with the application password doesn't have any of the Two Factor methods enabled.
+
+
 = Contribute =
 
 - Translate the plugin [into your language](https://translate.wordpress.org/projects/wp-plugins/application-passwords/).
 - Report issues, suggest features and contribute code [on GitHub](https://github.com/georgestephanis/application-passwords).
+
+
+= Creating Application Password Manually =
+
+1. Go the User Profile page of the user that you want to generate a new application password for.  To do so, click *Users* on the left side of the WordPress admin, then click on the user that you want to manage.
+2. Scroll down until you see the Application Passwords section.  This is typically at the bottom of the page.
+3. Within the input field, type in a name for your new application password, then click *Add New*.
+   **Note:** The application password name is only used to describe your password for easy management later.  It will not affect your password in any way.  Be descriptive, as it will lead to easier management if you ever need to change it later.
+4. Once the *Add New* button is clicked, your new application password will appear.  Be sure to keep this somewhere safe, as it will not be displayed to you again.  If you lose this password, it cannot be obtained again.
 
 
 = Requesting Password for Application =
@@ -32,19 +52,9 @@ To request a password for your application, redirect users to:
 and use the following `GET` request parameters to specify:
 
 - `app_name` (required) - The human readable identifier for your app. This will be the name of the generated application password, so structure it like ... "WordPress Mobile App on iPhone 12" for uniqueness between multiple versions. If omitted, the user will be required to provide an application name.
-
 - `success_url` (recommended) - The URL that you'd like the user to be sent to if they approve the connection. Two GET variables will be appended when they are passed back -- `user_login` and `password` -- these credentials can then be used for API calls. If the `success_url` variable is omitted, a password will be generated and displayed to the user, to manually enter into your application.
-
 - `reject_url` (optional) - If included, the user will get sent there if they reject the connection. If omitted, the user will be sent to the `success_url`, with `?success=false` appended to the end. If the `success_url` is omitted, the user will be sent to their dashboard.
 
-
-= Creating Application Password Manually =
-
-1. Go the User Profile page of the user that you want to generate a new application password for.  To do so, click *Users* on the left side of the WordPress admin, then click on the user that you want to manage.
-2. Scroll down until you see the Application Passwords section.  This is typically at the bottom of the page.
-3. Within the input field, type in a name for your new application password, then click *Add New*.
-   **Note:** The application password name is only used to describe your password for easy management later.  It will not affect your password in any way.  Be descriptive, as it will lead to easier management if you ever need to change it later.
-4. Once the *Add New* button is clicked, your new application password will appear.  Be sure to keep this somewhere safe, as it will not be displayed to you again.  If you lose this password, it cannot be obtained again.
 
 = Testing an Application Password =
 

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,7 @@ Creates unique passwords for applications to authenticate users without revealin
 
 Use Application Passwords to authenticate users without providing their passwords directly. Instead, a unique password is generated for each application without revealing the user's main password. Application passwords can be revoked for each application individually.
 
-**Important:** Application Passwords can be used only for authenticating API requests and they won't work for regular login.
+**Important:** Application Passwords can be used only for authenticating API requests such as [REST API](https://developer.wordpress.org/rest-api/) and [XML-RPC](https://codex.wordpress.org/XML-RPC_WordPress_API), and they won't work for regular site logins.
 
 
 = Contribute =

--- a/readme.txt
+++ b/readme.txt
@@ -58,37 +58,24 @@ and use the following `GET` request parameters to specify:
 
 = Testing an Application Password =
 
+We use [curl](https://curl.haxx.se) to send HTTP requests to the API endpoints in the examples below.
+
 #### WordPress REST API
 
-This test uses the technologies listed below, but you can use any REST API request.
+Make a REST API call to update a post. Because you are performing a `POST` request, you will need to authorize the request using your newly created base64 encoded access token. If authorized correctly, you will see the post title update to "New Title."
 
-* WordPress REST API
-* cURL
-* Mac OSX or Linux
-* A Mac or Linux terminal
-* Local development environment (e.g. MAMP, XAMPP, DesktopServer, Vagrant) running on localhost
+    curl --user "USERNAME:APPLICATION_PASSWORD" -X POST -d "title=New Title" https://LOCALHOST/wp-json/wp/v2/posts/POST_ID
 
-Make a REST API call using the terminal window to update a post. Because you are performing a `POST` request, you will need to authorize the request using your newly created base64 encoded access token. If authorized correctly, you will see the post title update to "New Title."
-
-    curl --user "USERNAME:APPLICATION_PASSWORD" -X POST -d "title=New Title" http://LOCALHOST/wp-json/wp/v2/posts/POST_ID
-
-When running this command, be sure to replace `USERNAME` and `APPLICATION_PASSWORD` with your credentials (curl takes care of base64 encoding and setting the `Authorization` header), `LOCALHOST` with the location of your local WordPress installation, and `POST_ID` with the ID of the post that you want to edit.
+When running this command, be sure to replace `USERNAME` and `APPLICATION_PASSWORD` with your credentials (curl takes care of base64 encoding and setting the `Authorization` header), `LOCALHOST` with the hostname of your WordPress installation, and `POST_ID` with the ID of the post that you want to edit.
 
 #### XML-RPC
 
-This test uses the technologies listed below, but you can use any XML-RPC request.
+Unlike the WordPress REST API, XML-RPC does not require your username and password to be base64 encoded. Send an XML-RPC request to list all users:
 
-* XML-RPC enabled within WordPress
-* cURL
-* Mac OSX or Linux
-* A Mac or Linux terminal
-* Local development environment (e.g. MAMP, DesktopServer, Vagrant) running on localhost
+    curl -H 'Content-Type: text/xml' -d '<methodCall><methodName>wp.getUsers</methodName><params><param><value>1</value></param><param><value>USERNAME</value></param><param><value>PASSWORD</value></param></params></methodCall>' https://LOCALHOST/xmlrpc.php
 
-Once you have created a new application password, it's time to send a request to test it. Unlike the WordPress REST API, XML-RPC does not require your username and password to be base64 encoded. To begin the process, open a terminal window and enter the following:
+In the above example, replace `USERNAME` with your username, `PASSWORD` with your new application password, and `LOCALHOST` with the hostname of your WordPress installation. This should output a response containing all users on your site.
 
-    curl -H 'Content-Type: text/xml' -d '<methodCall><methodName>wp.getUsers</methodName><params><param><value>1</value></param><param><value>USERNAME</value></param><param><value>PASSWORD</value></param></params></methodCall>' LOCALHOST
-
-In the above example, replace `USERNAME` with your username, and `PASSWORD` with your new application password. This should output a response containing all users on your site.
 
 = Plugin History =
 

--- a/readme.txt
+++ b/readme.txt
@@ -17,17 +17,6 @@ Use Application Passwords to authenticate users without providing their password
 **Important:** Application Passwords can be used only for authenticating API requests and they won't work for regular login.
 
 
-= Two Factor Support =
-
-Application Passwords can be used together with the [Two Factor plugin](https://wordpress.org/plugins/two-factor/) as long as you disable the extra protection added by the Two Factor plugin which disables API requests with password authentication _for users with Two Factor enabled_.
-
-Use the `two_factor_user_api_login_enable` filter to allow API requests with password-based authentication header for all users:
-
-    add_filter( 'two_factor_user_api_login_enable', '__return_true' );
-
-This is not required if the user associated with the application password doesn't have any of the Two Factor methods enabled.
-
-
 = Contribute =
 
 - Translate the plugin [into your language](https://translate.wordpress.org/projects/wp-plugins/application-passwords/).
@@ -41,6 +30,17 @@ This is not required if the user associated with the application password doesn'
 3. Within the input field, type in a name for your new application password, then click *Add New*.
    **Note:** The application password name is only used to describe your password for easy management later.  It will not affect your password in any way.  Be descriptive, as it will lead to easier management if you ever need to change it later.
 4. Once the *Add New* button is clicked, your new application password will appear.  Be sure to keep this somewhere safe, as it will not be displayed to you again.  If you lose this password, it cannot be obtained again.
+
+
+= Two Factor Support =
+
+Application Passwords can be used together with the [Two Factor plugin](https://wordpress.org/plugins/two-factor/) as long as you disable the extra protection added by the Two Factor plugin which disables API requests with password authentication _for users with Two Factor enabled_.
+
+Use the `two_factor_user_api_login_enable` filter to allow API requests with password-based authentication header for all users:
+
+    add_filter( 'two_factor_user_api_login_enable', '__return_true' );
+
+This is not required if the user associated with the application password doesn't have any of the Two Factor methods enabled.
 
 
 = Requesting Password for Application =

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Application Passwords ===
-Contributors: georgestephanis, valendesigns, kraftbj
+Contributors: georgestephanis, valendesigns, kraftbj, kasparsd
 Tags: application-passwords, rest api, xml-rpc, security, authentication
 Requires at least: 4.4
 Tested up to: 5.2

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ Creates unique passwords for applications to authenticate users without revealin
 
 == Description ==
 
-With Application Passwords you are able to authenticate users without providing their passwords directly. Instead, a unique password is generated for each application without revealing the user's main password. Application passwords can be revoked for each application individually.
+Use Application Passwords to authenticate users without providing their passwords directly. Instead, a unique password is generated for each application without revealing the user's main password. Application passwords can be revoked for each application individually.
 
 
 = Contribute =

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,8 @@ Creates unique passwords for applications to authenticate users without revealin
 
 Use Application Passwords to authenticate users without providing their passwords directly. Instead, a unique password is generated for each application without revealing the user's main password. Application passwords can be revoked for each application individually.
 
+**Important:** Application Passwords can be used only for authenticating API requests and they won't work for regular login.
+
 
 = Contribute =
 


### PR DESCRIPTION
- Document application password usage with user accounts that have [Two Factor](https://wordpress.org/plugins/two-factor/) enabled.
- Describe that application passwords can be used only with API requests (REST API, XML-RPC) -- they won't work for regular non-API logins.